### PR TITLE
Add a function to print a colorful banner

### DIFF
--- a/ascii.go
+++ b/ascii.go
@@ -1,25 +1,53 @@
 package ascii
 
 import (
-	"fmt"
-
-	"io"
+  "fmt"
+  "io"
+  "github.com/fatih/color"
 )
 
-// GrayMeta is the ASCII for the main logo.
-const GrayMeta = `  _____ _____        __     ____  __ ______ _______       
- / ____|  __ \     /\\ \   / /  \/  |  ____|__   __|/\  TM
-| |  __| |__) |   /  \\ \_/ /| \  / | |__     | |  /  \   
-| | |_ |  _  /   / /\ \\   / | |\/| |  __|    | | / /\ \  
-| |__| | | \ \  / ____ \| |  | |  | | |____   | |/ ____ \ 
- \_____|_|  \_\/_/    \_\_|  |_|  |_|______|  |_/_/    \_\
- `
+var grayLines = []string {
+  "   _____ _____        __     __",
+  `  / ____|  __ \     /\\ \   / `,
+  ` | |  __| |__) |   /  \\ \_/ /`,
+  ` | | |_ |  _  /   / /\ \\   / `,
+  ` | |__| | | \ \  / ____ \| |  `,
+  `  \_____|_|  \_\/_/    \_\_|  `,
+}
 
-// PrintBanner prints a command line banner to w.
+var redLines = []string {
+  "__  __ ______ _______",
+  `/  \/  |  ____|__   __|/\  TM`,
+  `| \  / | |__     | |  /  \`,
+  `| |\/| |  __|    | | / /\ \`,
+  `| |  | | |____   | |/ ____ \`,
+  `|_|  |_|______|  |_/_/    \_\`,
+}
+
+// Print a plaintext banner to w
 func PrintBanner(w io.Writer, name string, version interface{}) {
-	w.Write([]byte(GrayMeta))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "\t%s (v%v)\twww.graymeta.com", name, version)
-	fmt.Fprintln(w)
-	fmt.Fprintln(w)
+  writeBanner(w,name,version,fmt.Sprint,fmt.Sprint)
+}
+
+// Print a colorful banner to w.
+func ColorBanner(w io.Writer, name string, version interface{}) {
+  writeBanner(w,name,version,fmt.Sprint,color.New(color.FgRed).SprintFunc())
+}
+
+// Shorthand type definition for a string printing function
+type sprintFunc func(a ...interface{}) string
+
+// Writes a banner to w. grayFormat and redFormat are printing functions
+// that are used to write the different colors of text.
+func writeBanner(w io.Writer, name string, version interface{}, grayFormat sprintFunc, redFormat sprintFunc) {
+
+  for index, _ := range grayLines {
+    w.Write([]byte(grayFormat(grayLines[index])))
+    w.Write([]byte(redFormat(redLines[index])))
+    w.Write([]byte("\n"))
+  }
+  fmt.Fprintln(w)
+  fmt.Fprintf(w, "\t%s (v%v)\twww.graymeta.com", name, version)
+  fmt.Fprintln(w)
+  fmt.Fprintln(w)
 }


### PR DESCRIPTION
I thought it would be a nice touch for the 'META' to be red, just like it is in your logotype, so I added another function: `ascii.ColorBanner` that would output the necessary escape sequences to make the META red.
